### PR TITLE
Porting bugfixes from Java Selenium repo

### DIFF
--- a/TestFooter.py
+++ b/TestFooter.py
@@ -2,7 +2,7 @@ from BaseTest import BaseTest
 
 # TestFooter
 # Written by Angela Korra'ti
-# Last updated 4/26/2019
+# Last updated 7/5/2023
 #
 # Parent class for testing the footer. This class conducts tests against the homepage. Child classes will do
 # appropriate setup to test other pages.
@@ -59,23 +59,24 @@ class TestFooter(BaseTest):
         self.ac.move_to_element(self.wp_footer.footer_element).perform()
         self.ac.move_to_element(self.wp_footer.social_facebook_element).perform()
         self.wp_footer.social_facebook_element.click()
-        assert self.driver.current_url == self.wp_lib.footer_social_facebook['link'],\
+        facebook_wants_login = "https://www.facebook.com/login/?next=https%3A%2F%2Fwww.facebook.com%2Fannathepiper";
+        assert self.driver.current_url == facebook_wants_login,\
             "Clicking on Facebook link doesn't go to expected destination."
 
-    def verify_social_twitter(self):
+    def verify_social_mastodon(self):
         """
-        Verify the footer Twitter element is present and visible, and has the correct text and destination.
+        Verify the footer Mastodon element is present and visible, and has the correct text and destination.
         """
-        twitter_element = self.wp_footer.social_twitter_element
-        assert twitter_element is not None
-        assert twitter_element.is_displayed()
-        assert self.wp_footer.social_twitter_text == self.wp_lib.footer_social_twitter['text'],\
-            "Twitter link doesn't have correct text."
+        mastodon_element = self.wp_footer.social_mastodon_element
+        assert mastodon_element is not None
+        assert mastodon_element.is_displayed()
+        assert self.wp_footer.social_mastodon_text == self.wp_lib.footer_social_mastodon['text'],\
+            "Mastodon link doesn't have correct text."
         self.ac.move_to_element(self.wp_footer.footer_element).perform()
-        self.ac.move_to_element(self.wp_footer.social_twitter_element).perform()
-        self.wp_footer.social_twitter_element.click()
-        assert self.driver.current_url == self.wp_lib.footer_social_twitter['link'],\
-            "Clicking on Twitter link doesn't go to correct destination."
+        self.ac.move_to_element(self.wp_footer.social_mastodon_element).perform()
+        self.wp_footer.social_mastodon_element.click()
+        assert self.driver.current_url == self.wp_lib.footer_social_mastodon['link'],\
+            "Clicking on Mastodon link doesn't go to correct destination."
 
     def verify_social_github(self):
         """
@@ -104,4 +105,10 @@ class TestFooter(BaseTest):
         self.ac.move_to_element(self.wp_footer.footer_element).perform()
         self.ac.move_to_element(self.wp_footer.social_linkedin_element).perform()
         self.wp_footer.social_linkedin_element.click()
-        assert self.driver.current_url.startswith("https://www.linkedin.com")
+
+        # 7/5/2023 Current behavior of LinkedIn link is that sometimes the link has a referer
+        # parameter on the end and sometimes it doesn't, so let's check for both possibilities
+        linkedin_referer_suffix = "?original_referer=http%3A%2F%2Fwordpress.local%2F"
+        assert (self.driver.current_url == self.wp_lib.footer_social_linkedin['link']) or \
+               (self.driver.current_url == self.wp_lib.footer_social_linkedin['link'] + \
+                linkedin_referer_suffix)

--- a/TestHomepageFooter.py
+++ b/TestHomepageFooter.py
@@ -3,7 +3,7 @@ import WPHomepage
 
 # TestHomepageFooter
 # Written by Angela Korra'ti
-# Last updated 4/24/2019
+# Last updated 7/5/2023
 #
 # This class conducts tests against the footer on the homepage of my test Wordpress site.
 
@@ -36,11 +36,11 @@ class TestHomepageFooter(TestFooter):
         """
         self.verify_social_facebook()
 
-    def test_social_twitter(self):
+    def test_social_mastodon(self):
         """
-        Verify the footer Twitter element on the homepage
+        Verify the footer Mastodon element on the homepage
         """
-        self.verify_social_twitter()
+        self.verify_social_mastodon()
 
     def test_social_github(self):
         """

--- a/TestPostFooter.py
+++ b/TestPostFooter.py
@@ -3,7 +3,7 @@ import WPPost
 
 # TestFooter
 # Written by Angela Korra'ti
-# Last updated 4/26/2019
+# Last updated 7/5/2023
 #
 # This class conducts tests against the footer on a post of my test Wordpress site.
 
@@ -35,11 +35,11 @@ class TestPostFooter(TestFooter):
         """
         self.verify_social_facebook()
 
-    def test_social_twitter(self):
+    def test_social_mastodon(self):
         """
-        Verify the footer Twitter element on a post
+        Verify the footer Mastodon element on a post
         """
-        self.verify_social_twitter()
+        self.verify_social_mastodon()
 
     def test_social_github(self):
         """

--- a/WPFooter.py
+++ b/WPFooter.py
@@ -1,6 +1,6 @@
 # WPFooter
 # Written by Angela Korra'ti
-# Last updated 4/24/2019
+# Last updated 7/5/2023
 #
 # This is a helper class to define the layout of the footer. Used in turn by page level classes.
 
@@ -82,18 +82,18 @@ class WPFooter:
         return self.social_facebook_element.text
 
     @property
-    def social_twitter_element(self):
+    def social_mastodon_element(self):
         """
-        :return: The Webdriver element that refers to the Twitter link in the social section of the footer
+        :return: The Webdriver element that refers to the Mastodon link in the social section of the footer
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.footer_social_twitter['XPath'])
+        return self.driver.find_element_by_xpath(self.wp_lib.footer_social_mastodon['XPath'])
 
     @property
-    def social_twitter_text(self):
+    def social_mastodon_text(self):
         """
-        :return: The text of the footer social Twitter link
+        :return: The text of the footer social Mastodon link
         """
-        return self.social_twitter_element.text
+        return self.social_mastodon_element.text
 
     @property
     def social_github_element(self):

--- a/WPTestLib.py
+++ b/WPTestLib.py
@@ -42,8 +42,8 @@ class WPTestLib:
                       "link": "https://wordpress.org/"}
     footer_social_facebook = {"XPath": "//ul[@id='menu-social-1']/li[1]/a", "text": "Facebook",
                               "link": "https://www.facebook.com/annathepiper"}
-    footer_social_twitter = {"XPath": "//ul[@id='menu-social-1']/li[2]/a", "text": "Twitter",
-                             "link": "https://twitter.com/annathepiper"}
+    footer_social_mastodon = {"XPath": "//ul[@id='menu-social-1']/li[2]/a", "text": "Mastodon",
+                             "link": "https://mastodon.murkworks.net/@annathepiper"}
     footer_social_github = {"XPath": "//ul[@id='menu-social-1']/li[3]/a", "text": "GitHub",
                           "link": "https://github.com/annathepiper"}
     footer_social_linkedin = {"XPath": "//ul[@id='menu-social-1']/li[4]/a", "text": "LinkedIn",
@@ -92,23 +92,23 @@ class WPTestLib:
     sidebar_recent_posts_id = "recent-posts-2"
     sidebar_recent_posts_title_xpath = "//*[@id='recent-posts-2']/h2"
     sidebar_recent_posts_title_text = "RECENT POSTS"
-    sidebar_recent_posts_list_xpath = "//*[@id='recent-posts-2']/ul"
+    sidebar_recent_posts_list_xpath = "//*[@id='recent-posts-2']/*/ul"
     sidebar_recent_comments_id = "recent-comments-2"
     sidebar_recent_comments_title_xpath = "//*[@id='recent-comments-2']/h2"
     sidebar_recent_comments_title_text = "RECENT COMMENTS"
-    sidebar_recent_comments_list_xpath = "//*[@id='recent-comments-2']/ul"
+    sidebar_recent_comments_list_xpath = "//*[@id='recent-comments-2']/*/ul"
     sidebar_archives_id = "archives-2"
     sidebar_archives_title_xpath = "//*[@id='archives-2']/h2"
     sidebar_archives_title_text = "ARCHIVES"
-    sidebar_archives_list_xpath = "//*[@id='archives-2']/ul"
+    sidebar_archives_list_xpath = "//*[@id='archives-2']/*/ul"
     sidebar_categories_id = "categories-2"
     sidebar_categories_title_xpath = "//*[@id='categories-2']/h2"
     sidebar_categories_title_text = "CATEGORIES"
-    sidebar_categories_list_xpath = "//*[@id='categories-2']/ul"
+    sidebar_categories_list_xpath = "//*[@id='categories-2']/*/ul"
     sidebar_meta_id = "meta-2"
     sidebar_meta_title_xpath = "//*[@id='meta-2']/h2"
     sidebar_meta_title_text = "META"
-    sidebar_meta_list_xpath = "//*[@id='meta-2']/ul"
+    sidebar_meta_list_xpath = "//*[@id='meta-2']/*/ul"
 
     # Strings pertaining to search
     search_string = "Faerie Blood"
@@ -123,7 +123,7 @@ class WPTestLib:
     recent_posts_title = "angelahighland.info domain now active"
 
     # Strings pertaining to testing clicking on Recent Comments
-    recent_comments_uri = "/2016/09/12/hello-readers/#comment-2"
+    recent_comments_uri = "/2016/09/12/hello-readers/#comment-3"
     recent_comments_title = "Hello, readers!"
 
     # Strings pertaining to testing clicking on Archives


### PR DESCRIPTION
Applying the same bugfixes to this repo that I recently checked in on the Java Selenium demo:

1. Converted the tests for a Twitter link in the WordPress footer to looking for Mastodon instead
2. Corrected xpaths that changed due to WordPress upgrade
3. Corrected behavior of Facebook link test since Facebook now expects you to log in to see a page
4. Corrected behavior of LinkedIn link test since it's changed its behavior as well