### PR TITLE
A bunch of file renames and converting of syntax to pytest-style

### DIFF
--- a/BaseTest.py
+++ b/BaseTest.py
@@ -6,7 +6,7 @@ from abc import ABC
 
 # BaseTest
 # Written by Angela Korra'ti
-# Last updated 4/26/2019
+# Last updated 7/5/2023
 #
 # This is the base test class for the other ones in the suite.
 
@@ -16,7 +16,7 @@ class BaseTest(ABC):
     wp_lib = None
     ac = None
 
-    def setUp(self):
+    def setup_method(self):
         """
         Global setup function for all test classes that are children of BaseTest
         """
@@ -27,7 +27,7 @@ class BaseTest(ABC):
             desired_capabilities=caps)
         self.ac = ActionChains(self.driver)
 
-    def tearDown(self):
+    def teardown_method(self):
         """
         Global teardown function for all test classes that are children of BaseTest
         :return:

--- a/test_footer.py
+++ b/test_footer.py
@@ -59,8 +59,12 @@ class TestFooter(BaseTest):
         self.ac.move_to_element(self.wp_footer.footer_element).perform()
         self.ac.move_to_element(self.wp_footer.social_facebook_element).perform()
         self.wp_footer.social_facebook_element.click()
+
+        # 7/6/2023 Current behavior seems to be that Facebook may sometimes ask for a login
+        # and sometimes not. So I'm going to check for both scenarios.
         facebook_wants_login = "https://www.facebook.com/login/?next=https%3A%2F%2Fwww.facebook.com%2Fannathepiper";
-        assert self.driver.current_url == facebook_wants_login,\
+        assert self.driver.current_url == facebook_wants_login or \
+            self.driver.current_url == self.wp_lib.footer_social_facebook['link'], \
             "Clicking on Facebook link doesn't go to expected destination."
 
     def verify_social_mastodon(self):

--- a/test_homepage.py
+++ b/test_homepage.py
@@ -3,7 +3,7 @@ import WPHomepage
 
 # TestHomepage
 # Written by Angela Korra'ti
-# Last updated 4/24/2019
+# Last updated 7/6/2023
 #
 # This class conducts tests against the homepage of my test WordPress site.
 
@@ -12,11 +12,11 @@ class TestHomepage(BaseTest):
     wp_homepage = None
     wp_menu = None
 
-    def setUp(self):
+    def setup_method(self):
         """
         Do setup for the test cases.
         """
-        super().setUp()
+        super().setup_method()
         self.driver.get(self.wp_lib.wp_base_uri)
         self.wp_homepage = WPHomepage.WPHomepage(self.driver, self.wp_lib)
         self.wp_menu = self.wp_homepage.wp_menu

--- a/test_homepage_footer.py
+++ b/test_homepage_footer.py
@@ -1,20 +1,20 @@
-from TestFooter import TestFooter
+from test_footer import TestFooter
 import WPHomepage
 
 # TestHomepageFooter
 # Written by Angela Korra'ti
-# Last updated 7/5/2023
+# Last updated 7/6/2023
 #
 # This class conducts tests against the footer on the homepage of my test Wordpress site.
 
 
 class TestHomepageFooter(TestFooter):
 
-    def setUp(self):
+    def setup_method(self):
         """
         Do setup for the test cases.
         """
-        super().setUp()
+        super().setup_method()
         self.driver.get(self.wp_lib.wp_base_uri)
         super().set_wp_footer(WPHomepage.WPHomepage(self.driver, self.wp_lib).wp_footer)
 

--- a/test_homepage_menu.py
+++ b/test_homepage_menu.py
@@ -1,20 +1,20 @@
-from TestMenu import TestMenu
+from test_menu import TestMenu
 import WPHomepage
 
 # TestHomepageMenu
 # Written by Angela Korra'ti
-# Last updated 5/10/2019
+# Last updated 7/6/2023
 #
 # This class conducts tests against the menu on the homepage of my test WordPress site.
 
 
 class TestHomepageMenu(TestMenu):
 
-    def setUp(self):
+    def setup_method(self):
         """
         Do setup for the test cases.
         """
-        super().setUp()
+        super().setup_method()
         self.driver.get(self.wp_lib.wp_base_uri)
         super().set_wp_menu(WPHomepage.WPHomepage(self.driver, self.wp_lib).wp_menu)
 

--- a/test_homepage_search.py
+++ b/test_homepage_search.py
@@ -1,9 +1,9 @@
-from TestSearch import TestSearch
+from test_search import TestSearch
 import WPHomepage
 
 # TestHomepageSearch
 # Written by Angela Korra'ti
-# Last updated 5/10/2019
+# Last updated 7/6/2023
 #
 # This class conducts search tests against my test WordPress site.
 
@@ -11,11 +11,11 @@ import WPHomepage
 class TestHomepageSearch(TestSearch):
     wp_sidebar = None
 
-    def setUp(self):
+    def setup_method(self):
         """
         Do setup for the test cases.
         """
-        super().setUp()
+        super().setup_method()
         self.driver.get(self.wp_lib.wp_base_uri)
         self.wp_sidebar = WPHomepage.WPHomepage(self.driver, self.wp_lib).wp_sidebar
 

--- a/test_homepage_sidebar.py
+++ b/test_homepage_sidebar.py
@@ -1,20 +1,20 @@
-from TestSidebar import TestSidebar
+from test_sidebar import TestSidebar
 import WPHomepage
 
 # TestHomepageSidebar
 # Written by Angela Korra'ti
-# Last updated 5/10/2019
+# Last updated 7/6/2023
 #
 # This class conducts tests against the menu on the homepage of my test WordPress site.
 
 
 class TestHomepageSidebar(TestSidebar):
 
-    def setUp(self):
+    def setup_method(self):
         """
         Do setup for the test cases.
         """
-        super().setUp()
+        super().setup_method()
         self.driver.get(self.wp_lib.wp_base_uri)
         super().set_wp_sidebar(WPHomepage.WPHomepage(self.driver, self.wp_lib).wp_sidebar)
 

--- a/test_homepage_sidebar_links.py
+++ b/test_homepage_sidebar_links.py
@@ -1,9 +1,9 @@
-from TestSidebarLinks import TestSidebarLinks
+from test_sidebar_links import TestSidebarLinks
 import WPHomepage
 
 # TestHomepageSidebarLinks
 # Written by Angela Korra'ti
-# Last updated 5/10/2019
+# Last updated 7/6/2023
 #
 # This class conducts tests against the sidebar of my test WordPress site.
 
@@ -11,11 +11,11 @@ import WPHomepage
 class TestHomepageSidebarLinks(TestSidebarLinks):
     wp_sidebar = None
 
-    def setUp(self):
+    def setup_method(self):
         """
         Do setup for the test cases.
         """
-        super().setUp()
+        super().setup_method()
         self.driver.get(self.wp_lib.wp_base_uri)
         super().set_wp_sidebar(WPHomepage.WPHomepage(self.driver, self.wp_lib).wp_sidebar)
 

--- a/test_homepage_submenus.py
+++ b/test_homepage_submenus.py
@@ -1,20 +1,20 @@
-from TestSubmenus import TestSubmenus
+from test_submenus import TestSubmenus
 import WPHomepage
 
 # TestHomepageMenu
 # Written by Angela Korra'ti
-# Last updated 5/10/2019
+# Last updated 7/6/2023
 #
 # This class conducts tests against the submenus on the homepage of my test WordPress site.
 
 
 class TestHomepageSubmenus(TestSubmenus):
 
-    def setUp(self):
+    def setup_method(self):
         """
         Do setup for the test cases.
         """
-        super().setUp()
+        super().setup_method()
         self.driver.get(self.wp_lib.wp_base_uri)
         super().set_wp_menu(WPHomepage.WPHomepage(self.driver, self.wp_lib).wp_menu)
 

--- a/test_menu.py
+++ b/test_menu.py
@@ -2,7 +2,7 @@ from BaseTest import BaseTest
 
 # TestMenu
 # Written by Angela Korra'ti
-# Last updated 5/10/2019
+# Last updated 7/5/2023
 #
 # This class conducts tests against the main menu of my test Wordpress site.
 

--- a/test_post.py
+++ b/test_post.py
@@ -3,7 +3,7 @@ import WPPost
 
 # TestPost
 # Written by Angela Korra'ti
-# Last updated 5/10/2019
+# Last updated 7/6/2023
 #
 # This class conducts tests against a post on my test WordPress site.
 
@@ -12,11 +12,11 @@ class TestPost(BaseTest):
     wp_post = None
     wp_menu = None
 
-    def setUp(self):
+    def setup_method(self):
         """
         Do setup for the test cases.
         """
-        super().setUp()
+        super().setup_method()
         self.driver.get(self.wp_lib.wp_post_uri)
         self.wp_post = WPPost.WPPost(self.driver, self.wp_lib)
         self.wp_menu = self.wp_post.wp_menu

--- a/test_post_footer.py
+++ b/test_post_footer.py
@@ -1,19 +1,19 @@
-from TestFooter import TestFooter
+from test_footer import TestFooter
 import WPPost
 
 # TestFooter
 # Written by Angela Korra'ti
-# Last updated 7/5/2023
+# Last updated 7/6/2023
 #
 # This class conducts tests against the footer on a post of my test Wordpress site.
 
 
 class TestPostFooter(TestFooter):
-    def setUp(self):
+    def setup_method(self):
         """
         Do setup for the test cases.
         """
-        super().setUp()
+        super().setup_method()
         self.driver.get(self.wp_lib.wp_post_uri)
         super().set_wp_footer(WPPost.WPPost(self.driver, self.wp_lib).wp_footer)
 

--- a/test_post_menu.py
+++ b/test_post_menu.py
@@ -1,20 +1,20 @@
-from TestMenu import TestMenu
+from test_menu import TestMenu
 import WPPost
 
 # TestPostMenu
 # Written by Angela Korra'ti
-# Last updated 5/10/2019
+# Last updated 7/6/2023
 #
 # This class conducts tests against the menu on a post of my test WordPress site.
 
 
 class TestPostMenu(TestMenu):
 
-    def setUp(self):
+    def setup_method(self):
         """
         Do setup for the test cases.
         """
-        super().setUp()
+        super().setup_method()
         self.driver.get(self.wp_lib.wp_post_uri)
         super().set_wp_menu(WPPost.WPPost(self.driver, self.wp_lib).wp_menu)
 

--- a/test_post_search.py
+++ b/test_post_search.py
@@ -1,9 +1,9 @@
-from TestSearch import TestSearch
+from test_search import TestSearch
 import WPPost
 
 # TestPostSearch
 # Written by Angela Korra'ti
-# Last updated 5/10/2019
+# Last updated 7/6/2023
 #
 # This class conducts search tests against my test WordPress site.
 
@@ -11,11 +11,11 @@ import WPPost
 class TestPostSearch(TestSearch):
     wp_sidebar = None
 
-    def setUp(self):
+    def setup_method(self):
         """
         Do setup for the test cases.
         """
-        super().setUp()
+        super().setup_method()
         self.driver.get(self.wp_lib.wp_post_uri)
         self.wp_sidebar = WPPost.WPPost(self.driver, self.wp_lib).wp_sidebar
 

--- a/test_post_sidebar.py
+++ b/test_post_sidebar.py
@@ -1,20 +1,20 @@
-from TestSidebar import TestSidebar
+from test_sidebar import TestSidebar
 import WPPost
 
 # TestPostSidebar
 # Written by Angela Korra'ti
-# Last updated 5/10/2019
+# Last updated 7/6/2023
 #
 # This class conducts tests against the menu on a post of my test WordPress site.
 
 
 class TestPostSidebar(TestSidebar):
 
-    def setUp(self):
+    def setup_method(self):
         """
         Do setup for the test cases.
         """
-        super().setUp()
+        super().setup_method()
         self.driver.get(self.wp_lib.wp_post_uri)
         super().set_wp_sidebar(WPPost.WPPost(self.driver, self.wp_lib).wp_sidebar)
 

--- a/test_post_sidebar_links.py
+++ b/test_post_sidebar_links.py
@@ -1,9 +1,9 @@
-from TestSidebarLinks import TestSidebarLinks
+from test_sidebar_links import TestSidebarLinks
 import WPPost
 
 # TestPostSidebarLinks
 # Written by Angela Korra'ti
-# Last updated 5/10/2019
+# Last updated 7/6/2023
 #
 # This class conducts tests against the sidebar of my test WordPress site.
 
@@ -11,11 +11,11 @@ import WPPost
 class TestPostSidebarLinks(TestSidebarLinks):
     wp_sidebar = None
 
-    def setUp(self):
+    def setup_method(self):
         """
         Do setup for the test cases.
         """
-        super().setUp()
+        super().setup_method()
         self.driver.get(self.wp_lib.wp_post_uri)
         super().set_wp_sidebar(WPPost.WPPost(self.driver, self.wp_lib).wp_sidebar)
 

--- a/test_post_submenus.py
+++ b/test_post_submenus.py
@@ -1,20 +1,20 @@
-from TestSubmenus import TestSubmenus
+from test_submenus import TestSubmenus
 import WPPost
 
 # TestPostMenu
 # Written by Angela Korra'ti
-# Last updated 5/10/2019
+# Last updated 7/6/2023
 #
 # This class conducts tests against the submenus on a post of my test WordPress site.
 
 
 class TestPostSubmenus(TestSubmenus):
 
-    def setUp(self):
+    def setup_method(self):
         """
         Do setup for the test cases.
         """
-        super().setUp()
+        super().setup_method()
         self.driver.get(self.wp_lib.wp_post_uri)
         super().set_wp_menu(WPPost.WPPost(self.driver, self.wp_lib).wp_menu)
 

--- a/test_search.py
+++ b/test_search.py
@@ -3,7 +3,7 @@ from BaseTest import BaseTest
 
 # TestSearch
 # Written by Angela Korra'ti
-# Last updated 5/10/2019
+# Last updated 7/5/2023
 #
 # This class conducts search tests against my test WordPress site.
 

--- a/test_sidebar.py
+++ b/test_sidebar.py
@@ -2,7 +2,7 @@ from BaseTest import BaseTest
 
 # TestSidebar
 # Written by Angela Korra'ti
-# Last updated 5/10/2019
+# Last updated 7/5/2023
 #
 # This class conducts tests against the sidebar of my test WordPress site.
 

--- a/test_sidebar_links.py
+++ b/test_sidebar_links.py
@@ -3,7 +3,7 @@ import WPPost
 
 # TestSidebarLinks
 # Written by Angela Korra'ti
-# Last updated 5/10/2019
+# Last updated 7/5/2023
 #
 # This class conducts tests against the sidebar of my test WordPress site.
 

--- a/test_submenus.py
+++ b/test_submenus.py
@@ -4,7 +4,7 @@ from selenium.webdriver.common.action_chains import ActionChains
 
 # TestSubmenus
 # Written by Angela Korra'ti
-# Last updated 5/10/2019
+# Last updated 7/5/2023
 #
 # This class conducts tests against the menu dropdowns on the main menu of my test Wordpress site.
 


### PR DESCRIPTION
Converting this suite to be able to run under pytest instead of nose, since nose is very deprecated and nobody's using it anymore.

Main changes include:
1. Renamed a bunch of files so pytest could scan them for tests properly
2. Renamed a bunch of setup and teardown methods to setup_method and teardown_method
3. Tweak of footer test case that tests the Facebook link since Facebook's still doing weird behavior with whether or not it enforces a login