### PR TITLE
Selenium 4 capabilities and syntax fixes

### DIFF
--- a/BaseTest.py
+++ b/BaseTest.py
@@ -3,6 +3,7 @@ from selenium import webdriver
 import WPTestLib
 from selenium.webdriver.common.action_chains import ActionChains
 from abc import ABC
+from selenium.webdriver.chrome.options import Options as ChromeOptions
 
 # BaseTest
 # Written by Angela Korra'ti
@@ -21,10 +22,9 @@ class BaseTest(ABC):
         Global setup function for all test classes that are children of BaseTest
         """
         self.wp_lib = WPTestLib.WPTestLib()
-        caps = {'browserName': os.getenv('BROWSER', 'chrome')}
-        self.driver = webdriver.Remote(
-            command_executor=self.wp_lib.selenium_host,
-            desired_capabilities=caps)
+        options = ChromeOptions()
+        options.set_capability('browserName', os.getenv('BROWSER', 'chrome'))
+        self.driver = webdriver.Remote(self.wp_lib.selenium_host, options=options)
         self.ac = ActionChains(self.driver)
 
     def teardown_method(self):

--- a/WPFooter.py
+++ b/WPFooter.py
@@ -1,6 +1,8 @@
+from selenium.webdriver.common.by import By
+
 # WPFooter
 # Written by Angela Korra'ti
-# Last updated 7/5/2023
+# Last updated 7/7/2023
 #
 # This is a helper class to define the layout of the footer. Used in turn by page level classes.
 
@@ -23,28 +25,28 @@ class WPFooter:
         """
         :return: The Webdriver element that refers to the footer
         """
-        return self.driver.find_element_by_id(self.wp_lib.footer_id)
+        return self.driver.find_element(By.ID, self.wp_lib.footer_id)
 
     @property
     def social_menu_element(self):
         """
         :return: The Webdriver element that refers to the footer social menu
         """
-        return self.driver.find_element_by_id(self.wp_lib.footer_social_menu_id)
+        return self.driver.find_element(By.ID, self.wp_lib.footer_social_menu_id)
 
     @property
     def site_info_element(self):
         """
         :return: The Webdriver element that refers to the footer site info section
         """
-        return self.driver.find_element_by_class_name(self.wp_lib.footer_site_info_class)
+        return self.driver.find_element(By.CLASS_NAME, self.wp_lib.footer_site_info_class)
 
     @property
     def site_title_element(self):
         """
         :return: The Webdriver element that refers to the footer site title section
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.footer_site_title_xpath)
+        return self.driver.find_element(By.XPATH, self.wp_lib.footer_site_title_xpath)
 
     @property
     def site_title_text(self):
@@ -58,7 +60,7 @@ class WPFooter:
         """
         :return: The Webdriver element that refers to the footer Wordpress link
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.footer_wp_link['XPath'])
+        return self.driver.find_element(By.XPATH, self.wp_lib.footer_wp_link['XPath'])
 
     @property
     def wordpress_element_text(self):
@@ -72,7 +74,7 @@ class WPFooter:
         """
         :return: The Webdriver element that refers to the Facebook link in the social section of the footer
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.footer_social_facebook['XPath'])
+        return self.driver.find_element(By.XPATH, self.wp_lib.footer_social_facebook['XPath'])
 
     @property
     def social_facebook_text(self):
@@ -86,7 +88,7 @@ class WPFooter:
         """
         :return: The Webdriver element that refers to the Mastodon link in the social section of the footer
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.footer_social_mastodon['XPath'])
+        return self.driver.find_element(By.XPATH, self.wp_lib.footer_social_mastodon['XPath'])
 
     @property
     def social_mastodon_text(self):
@@ -100,7 +102,7 @@ class WPFooter:
         """
         :return: The Webdriver element that refers to the Github link in the social section of the footer
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.footer_social_github['XPath'])
+        return self.driver.find_element(By.XPATH, self.wp_lib.footer_social_github['XPath'])
 
     @property
     def social_github_text(self):
@@ -114,7 +116,7 @@ class WPFooter:
         """
         :return: The Webdriver element that refers to the LinkedIn link in the social section of the footer
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.footer_social_linkedin['XPath'])
+        return self.driver.find_element(By.XPATH, self.wp_lib.footer_social_linkedin['XPath'])
 
     @property
     def social_linkedin_text(self):

--- a/WPHomepage.py
+++ b/WPHomepage.py
@@ -1,10 +1,11 @@
 import WPMenu
 import WPSidebar
 import WPFooter
+from selenium.webdriver.common.by import By
 
 # WPHomepage
 # Written by Angela Korra'ti
-# Last updated 4/24/2019
+# Last updated 7/7/2023
 #
 # This is a helper class to define the layout of the homepage of the test site.
 
@@ -39,14 +40,14 @@ class WPHomepage:
         """
         :return: The Webdriver element that refers to the site title.
         """
-        return self.driver.find_element_by_class_name(self.wp_lib.site_title['class'])
+        return self.driver.find_element(By.CLASS_NAME, self.wp_lib.site_title['class'])
 
     @property
     def site_title(self):
         """
         :return: The text of the site title.
         """
-        site_title_element = self.driver.find_element_by_class_name(self.wp_lib.site_title['class'])
+        site_title_element = self.driver.find_element(By.CLASS_NAME, self.wp_lib.site_title['class'])
         return site_title_element.text
 
     @property
@@ -54,14 +55,14 @@ class WPHomepage:
         """
         :return: The Webdriver element that refers to the site description.
         """
-        return self.driver.find_element_by_class_name(self.wp_lib.site_description['class'])
+        return self.driver.find_element(By.CLASS_NAME, self.wp_lib.site_description['class'])
 
     @property
     def site_description(self):
         """
         :return: The text of the site description.
         """
-        site_description_element = self.driver.find_element_by_class_name(self.wp_lib.site_description['class'])
+        site_description_element = self.driver.find_element(By.CLASS_NAME, self.wp_lib.site_description['class'])
         return site_description_element.text
 
     @property
@@ -69,18 +70,18 @@ class WPHomepage:
         """
         :return: The Webdriver element that refers to the overall content area.
         """
-        return self.driver.find_element_by_id(self.wp_lib.content_id)
+        return self.driver.find_element(By.ID, self.wp_lib.content_id)
 
     @property
     def primary_content_area_element(self):
         """
         :return: The Webdriver element that refers to the primary content area.
         """
-        return self.driver.find_element_by_id(self.wp_lib.primary_content_id)
+        return self.driver.find_element(By.ID, self.wp_lib.primary_content_id)
 
     @property
     def secondary_content_area_element(self):
         """
         :return: The Webdriver element that refers to the secondary content area.
         """
-        return self.driver.find_element_by_id(self.wp_lib.secondary_content_id)
+        return self.driver.find_element(By.ID, self.wp_lib.secondary_content_id)

--- a/WPMenu.py
+++ b/WPMenu.py
@@ -1,6 +1,8 @@
+from selenium.webdriver.common.by import By
+
 # WPMenu
 # Written by Angela Korra'ti
-# Last updated 2/11/2019
+# Last updated 7/7/2023
 #
 # This is a helper class to define the layout of the main menu. Used in turn by page level classes.
 
@@ -23,14 +25,14 @@ class WPMenu:
         """
         :return: The Webdriver element pointing at the main menu
         """
-        return self.driver.find_element_by_id(self.wp_lib.menu_id)
+        return self.driver.find_element(By.ID, self.wp_lib.menu_id)
 
     @property
     def home_menu_element(self):
         """
         :return: The Webdriver element pointing at the Home menu item
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.menu_home['XPath'])
+        return self.driver.find_element(By.XPATH, self.wp_lib.menu_home['XPath'])
 
     @property
     def home_menu_text(self):
@@ -51,7 +53,7 @@ class WPMenu:
         """
         :return: The Webdriver element pointing at the submenu under Home
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.submenu_home['XPath'])
+        return self.driver.find_element(By.XPATH, self.wp_lib.submenu_home['XPath'])
 
     @property
     def home_submenu_text(self):
@@ -72,7 +74,7 @@ class WPMenu:
         """
         :return: The Webdriver element pointing at the About menu item
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.menu_about['XPath'])
+        return self.driver.find_element(By.XPATH, self.wp_lib.menu_about['XPath'])
 
     @property
     def about_menu_text(self):
@@ -93,7 +95,7 @@ class WPMenu:
         """
         :return: The Webdriver element pointing at the Books menu item
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.menu_books['XPath'])
+        return self.driver.find_element(By.XPATH, self.wp_lib.menu_books['XPath'])
 
     @property
     def books_menu_text(self):
@@ -114,14 +116,14 @@ class WPMenu:
         """
         :return: The Webdriver element pointing at the submenu under Books
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.submenu_books_xpath)
+        return self.driver.find_element(By.XPATH, self.wp_lib.submenu_books_xpath)
 
     @property
     def faerie_submenu_element(self):
         """
         :return: The Webdriver element pointing to the Faerie Blood item under Books
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.submenu_faerie['XPath'])
+        return self.driver.find_element(By.XPATH, self.wp_lib.submenu_faerie['XPath'])
 
     @property
     def faerie_submenu_text(self):
@@ -142,7 +144,7 @@ class WPMenu:
         """
         :return: The Webdriver element pointing to the Bone Walker item under Books
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.submenu_bone['XPath'])
+        return self.driver.find_element(By.XPATH, self.wp_lib.submenu_bone['XPath'])
 
     @property
     def bone_submenu_text(self):
@@ -163,7 +165,7 @@ class WPMenu:
         """
         :return: The Webdriver element pointing to the Valor of the Healer item under Books
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.submenu_valor['XPath'])
+        return self.driver.find_element(By.XPATH, self.wp_lib.submenu_valor['XPath'])
 
     @property
     def valor_submenu_text(self):
@@ -184,7 +186,7 @@ class WPMenu:
         """
         :return: The Webdriver element pointing to the Vengeance of the Hunter item under Books
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.submenu_vengeance['XPath'])
+        return self.driver.find_element(By.XPATH, self.wp_lib.submenu_vengeance['XPath'])
 
     @property
     def vengeance_submenu_text(self):
@@ -205,7 +207,7 @@ class WPMenu:
         """
         :return: The Webdriver element pointing to the Victory of the Hawk item under Books
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.submenu_victory['XPath'])
+        return self.driver.find_element(By.XPATH, self.wp_lib.submenu_victory['XPath'])
 
     @property
     def victory_submenu_text(self):
@@ -226,7 +228,7 @@ class WPMenu:
         """
         :return: The Webdriver element pointing to the Short Stories item under Books
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.submenu_short['XPath'])
+        return self.driver.find_element(By.XPATH, self.wp_lib.submenu_short['XPath'])
 
     @property
     def short_submenu_text(self):
@@ -247,7 +249,7 @@ class WPMenu:
         """
         :return: The Webdriver element pointing at the Blog menu item
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.menu_blog['XPath'])
+        return self.driver.find_element(By.XPATH, self.wp_lib.menu_blog['XPath'])
 
     @property
     def blog_menu_text(self):
@@ -268,7 +270,7 @@ class WPMenu:
         """
         :return: The Webdriver element pointing at the Contact menu item
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.menu_contact['XPath'])
+        return self.driver.find_element(By.XPATH, self.wp_lib.menu_contact['XPath'])
 
     @property
     def contact_menu_text(self):
@@ -289,7 +291,7 @@ class WPMenu:
         """
         :return: The Webdriver element pointing at the Store menu item
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.menu_store['XPath'])
+        return self.driver.find_element(By.XPATH, self.wp_lib.menu_store['XPath'])
 
     @property
     def store_menu_text(self):
@@ -310,7 +312,7 @@ class WPMenu:
         """
         :return: The Webdriver element pointing at the submenu under Store
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.submenu_store['XPath'])
+        return self.driver.find_element(By.XPATH, self.wp_lib.submenu_store['XPath'])
 
     @property
     def store_submenu_text(self):

--- a/WPPost.py
+++ b/WPPost.py
@@ -1,10 +1,11 @@
 import WPMenu
 import WPSidebar
 import WPFooter
+from selenium.webdriver.common.by import By
 
 # WPPost
 # Written by Angela Korra'ti
-# Last updated 5/10/2019
+# Last updated 7/7/2023
 #
 # This is a helper class to define the layout of a post on the test site.
 
@@ -39,14 +40,14 @@ class WPPost:
         """
         :return: The Webdriver element that refers to the site title.
         """
-        return self.driver.find_element_by_class_name(self.wp_lib.site_title['class'])
+        return self.driver.find_element(By.CLASS_NAME, self.wp_lib.site_title['class'])
 
     @property
     def site_title(self):
         """
         :return: The text of the site title.
         """
-        site_title_element = self.driver.find_element_by_class_name(self.wp_lib.site_title['class'])
+        site_title_element = self.driver.find_element(By.CLASS_NAME, self.wp_lib.site_title['class'])
         return site_title_element.text
 
     @property
@@ -54,14 +55,14 @@ class WPPost:
         """
         :return: The Webdriver element that refers to the site description.
         """
-        return self.driver.find_element_by_class_name(self.wp_lib.site_description['class'])
+        return self.driver.find_element(By.CLASS_NAME, self.wp_lib.site_description['class'])
 
     @property
     def site_description(self):
         """
         :return: The text of the site description.
         """
-        site_description_element = self.driver.find_element_by_class_name(self.wp_lib.site_description['class'])
+        site_description_element = self.driver.find_element(By.CLASS_NAME, self.wp_lib.site_description['class'])
         return site_description_element.text
 
     @property
@@ -69,28 +70,28 @@ class WPPost:
         """
         :return: The Webdriver element that refers to the overall content area.
         """
-        return self.driver.find_element_by_id(self.wp_lib.content_id)
+        return self.driver.find_element(By.ID, self.wp_lib.content_id)
 
     @property
     def primary_content_area_element(self):
         """
         :return: The Webdriver element that refers to the primary content area.
         """
-        return self.driver.find_element_by_id(self.wp_lib.primary_content_id)
+        return self.driver.find_element(By.ID, self.wp_lib.primary_content_id)
 
     @property
     def secondary_content_area_element(self):
         """
         :return: The Webdriver element that refers to the secondary content area.
         """
-        return self.driver.find_element_by_id(self.wp_lib.secondary_content_id)
+        return self.driver.find_element(By.ID, self.wp_lib.secondary_content_id)
 
     @property
     def post_title_element(self):
         """
         :return: The Webdriver element that refers to the post title.
         """
-        return self.driver.find_element_by_class_name(self.wp_lib.entry_title_class)
+        return self.driver.find_element(By.CLASS_NAME, self.wp_lib.entry_title_class)
 
     @property
     def post_title_text(self):

--- a/WPSidebar.py
+++ b/WPSidebar.py
@@ -1,3 +1,5 @@
+from selenium.webdriver.common.by import By
+
 # WPSidebar
 # Written by Angela Korra'ti
 # Last updated 5/10/2019
@@ -23,35 +25,35 @@ class WPSidebar:
         """
         :return: Webdriver element pointing at the search widget
         """
-        return self.driver.find_element_by_id(self.wp_lib.sidebar_search_id)
+        return self.driver.find_element(By.ID, self.wp_lib.sidebar_search_id)
 
     @property
     def search_input_element(self):
         """
         :return: Webdriver element pointing at the search input box
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.sidebar_search_input_xpath)
+        return self.driver.find_element(By.XPATH, self.wp_lib.sidebar_search_input_xpath)
 
     @property
     def search_button_element(self):
         """
         :return: Webdriver element pointing at the search button
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.sidebar_search_button_xpath)
+        return self.driver.find_element(By.XPATH, self.wp_lib.sidebar_search_button_xpath)
 
     @property
     def recent_posts_element(self):
         """
         :return: Webdriver element pointing at the recent posts widget
         """
-        return self.driver.find_element_by_id(self.wp_lib.sidebar_recent_posts_id)
+        return self.driver.find_element(By.ID, self.wp_lib.sidebar_recent_posts_id)
 
     @property
     def recent_posts_title_element(self):
         """
         :return: Webdriver element pointing at the recent posts title
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.sidebar_recent_posts_title_xpath)
+        return self.driver.find_element(By.XPATH, self.wp_lib.sidebar_recent_posts_title_xpath)
 
     @property
     def recent_posts_title_text(self):
@@ -65,28 +67,28 @@ class WPSidebar:
         """
         :return: Webdriver element pointing at the list of recent posts
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.sidebar_recent_posts_list_xpath)
+        return self.driver.find_element(By.XPATH, self.wp_lib.sidebar_recent_posts_list_xpath)
 
     @property
     def recent_posts_list_elements(self):
         """
         :return: List of webdriver elements pointing at the recent post links
         """
-        return self.driver.find_elements_by_xpath(self.wp_lib.sidebar_recent_posts_list_xpath + "/li/a")
+        return self.driver.find_elements(By.XPATH, self.wp_lib.sidebar_recent_posts_list_xpath + "/li/a")
 
     @property
     def recent_comments_element(self):
         """
         :return: Webdriver element pointing at the recent comments widget
         """
-        return self.driver.find_element_by_id(self.wp_lib.sidebar_recent_comments_id)
+        return self.driver.find_element(By.ID, self.wp_lib.sidebar_recent_comments_id)
 
     @property
     def recent_comments_title_element(self):
         """
         :return: Webdriver element pointing at the recent comments title
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.sidebar_recent_comments_title_xpath)
+        return self.driver.find_element(By.XPATH, self.wp_lib.sidebar_recent_comments_title_xpath)
 
     @property
     def recent_comments_title_text(self):
@@ -100,28 +102,28 @@ class WPSidebar:
         """
         :return: Webdriver element pointing at the list of recent comments
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.sidebar_recent_comments_list_xpath)
+        return self.driver.find_element(By.XPATH, self.wp_lib.sidebar_recent_comments_list_xpath)
 
     @property
     def recent_comments_list_elements(self):
         """
         :return: List of webdriver elements pointing at the recent comment links
         """
-        return self.driver.find_elements_by_xpath(self.wp_lib.sidebar_recent_comments_list_xpath + "/li/a")
+        return self.driver.find_elements(By.XPATH, self.wp_lib.sidebar_recent_comments_list_xpath + "/li/a")
 
     @property
     def archives_element(self):
         """
         :return: Webdriver element pointing at the archives widget
         """
-        return self.driver.find_element_by_id(self.wp_lib.sidebar_archives_id)
+        return self.driver.find_element(By.ID, self.wp_lib.sidebar_archives_id)
 
     @property
     def archives_title_element(self):
         """
         :return: Webdriver element pointing at the archives title
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.sidebar_archives_title_xpath)
+        return self.driver.find_element(By.XPATH, self.wp_lib.sidebar_archives_title_xpath)
 
     @property
     def archives_title_text(self):
@@ -135,28 +137,28 @@ class WPSidebar:
         """
         :return: Webdriver element pointing at the list of archives
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.sidebar_archives_list_xpath)
+        return self.driver.find_element(By.XPATH, self.wp_lib.sidebar_archives_list_xpath)
 
     @property
     def archives_list_elements(self):
         """
         :return: List of webdriver elements pointing at the archives links
         """
-        return self.driver.find_elements_by_xpath(self.wp_lib.sidebar_archives_list_xpath + "/li/a")
+        return self.driver.find_elements(By.XPATH, self.wp_lib.sidebar_archives_list_xpath + "/li/a")
 
     @property
     def categories_element(self):
         """
         :return: Webdriver element pointing at the categories widget
         """
-        return self.driver.find_element_by_id(self.wp_lib.sidebar_categories_id)
+        return self.driver.find_element(By.ID, self.wp_lib.sidebar_categories_id)
 
     @property
     def categories_title_element(self):
         """
         :return: Webdriver element pointing at the categories title
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.sidebar_categories_title_xpath)
+        return self.driver.find_element(By.XPATH, self.wp_lib.sidebar_categories_title_xpath)
 
     @property
     def categories_title_text(self):
@@ -170,28 +172,28 @@ class WPSidebar:
         """
         :return: Webdriver element pointing at the list of categories
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.sidebar_categories_list_xpath)
+        return self.driver.find_element(By.XPATH, self.wp_lib.sidebar_categories_list_xpath)
 
     @property
     def categories_list_elements(self):
         """
         :return: List of webdriver elements pointing at the categories links
         """
-        return self.driver.find_elements_by_xpath(self.wp_lib.sidebar_categories_list_xpath + "/li/a")
+        return self.driver.find_elements(By.XPATH, self.wp_lib.sidebar_categories_list_xpath + "/li/a")
 
     @property
     def meta_element(self):
         """
         :return: Webdriver element pointing at the meta widget
         """
-        return self.driver.find_element_by_id(self.wp_lib.sidebar_meta_id)
+        return self.driver.find_element(By.ID, self.wp_lib.sidebar_meta_id)
 
     @property
     def meta_title_element(self):
         """
         :return: Webdriver element pointing at the meta title
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.sidebar_meta_title_xpath)
+        return self.driver.find_element(By.XPATH, self.wp_lib.sidebar_meta_title_xpath)
 
     @property
     def meta_title_text(self):
@@ -205,11 +207,11 @@ class WPSidebar:
         """
         :return: Webdriver element pointing at the list of meta links
         """
-        return self.driver.find_element_by_xpath(self.wp_lib.sidebar_meta_list_xpath)
+        return self.driver.find_element(By.XPATH, self.wp_lib.sidebar_meta_list_xpath)
 
     @property
     def meta_list_elements(self):
         """
         :return: List of webdriver elements pointing at the meta links
         """
-        return self.driver.find_elements_by_xpath(self.wp_lib.sidebar_meta_list_xpath + "/li/a")
+        return self.driver.find_elements(By.XPATH, self.wp_lib.sidebar_meta_list_xpath + "/li/a")

--- a/WPTestLib.py
+++ b/WPTestLib.py
@@ -123,7 +123,7 @@ class WPTestLib:
     recent_posts_title = "angelahighland.info domain now active"
 
     # Strings pertaining to testing clicking on Recent Comments
-    recent_comments_uri = "/2016/09/12/hello-readers/#comment-3"
+    recent_comments_uri = "/2016/09/12/hello-readers/#comment-"
     recent_comments_title = "Hello, readers!"
 
     # Strings pertaining to testing clicking on Archives

--- a/test_homepage_search.py
+++ b/test_homepage_search.py
@@ -1,9 +1,10 @@
 from test_search import TestSearch
 import WPHomepage
+from selenium.webdriver.common.by import By
 
 # TestHomepageSearch
 # Written by Angela Korra'ti
-# Last updated 7/6/2023
+# Last updated 7/7/2023
 #
 # This class conducts search tests against my test WordPress site.
 
@@ -50,7 +51,7 @@ class TestHomepageSearch(TestSearch):
         assert self.driver.current_url == self.wp_lib.wp_base_uri + self.wp_lib.search_no_results_uri
 
         # Make sure the search string is appropriately reflected in the page title
-        page_title = self.driver.find_element_by_class_name(self.wp_lib.page_title_class)
+        page_title = self.driver.find_element(By.CLASS_NAME, self.wp_lib.page_title_class)
         assert page_title is not None
         assert page_title.is_displayed()
         assert page_title.text == self.wp_lib.search_no_results_message

--- a/test_search.py
+++ b/test_search.py
@@ -1,9 +1,10 @@
 from selenium.webdriver.common.keys import Keys
 from BaseTest import BaseTest
+from selenium.webdriver.common.by import By
 
 # TestSearch
 # Written by Angela Korra'ti
-# Last updated 7/5/2023
+# Last updated 7/7/2023
 #
 # This class conducts search tests against my test WordPress site.
 
@@ -29,7 +30,7 @@ class TestSearch(BaseTest):
         assert self.driver.current_url == self.wp_lib.wp_base_uri + self.wp_lib.search_uri
 
         # Make sure the search string is appropriately reflected in the page title
-        page_title = self.driver.find_element_by_class_name(self.wp_lib.page_title_class)
+        page_title = self.driver.find_element(By.CLASS_NAME, self.wp_lib.page_title_class)
         assert page_title is not None
         assert page_title.is_displayed()
         assert page_title.text == self.wp_lib.search_results_string + self.wp_lib.search_string
@@ -47,7 +48,7 @@ class TestSearch(BaseTest):
         assert self.driver.current_url == self.wp_lib.wp_base_uri + self.wp_lib.search_uri
 
         # Make sure the search string is appropriately reflected in the page title
-        page_title = self.driver.find_element_by_class_name(self.wp_lib.page_title_class)
+        page_title = self.driver.find_element(By.CLASS_NAME, self.wp_lib.page_title_class)
         assert page_title is not None
         assert page_title.is_displayed()
         assert page_title.text == self.wp_lib.search_results_string + self.wp_lib.search_string
@@ -64,7 +65,7 @@ class TestSearch(BaseTest):
         assert self.driver.current_url == self.wp_lib.wp_base_uri + self.wp_lib.search_no_results_uri
 
         # Make sure the search string is appropriately reflected in the page title
-        page_title = self.driver.find_element_by_class_name(self.wp_lib.page_title_class)
+        page_title = self.driver.find_element(By.CLASS_NAME, self.wp_lib.page_title_class)
         assert page_title is not None
         assert page_title.is_displayed()
         assert page_title.text == self.wp_lib.search_no_results_message
@@ -82,7 +83,7 @@ class TestSearch(BaseTest):
         assert self.driver.current_url == self.wp_lib.wp_base_uri + self.wp_lib.search_no_results_uri
 
         # Make sure the search string is appropriately reflected in the page title
-        page_title = self.driver.find_element_by_class_name(self.wp_lib.page_title_class)
+        page_title = self.driver.find_element(By.CLASS_NAME, self.wp_lib.page_title_class)
         assert page_title is not None
         assert page_title.is_displayed()
         assert page_title.text == self.wp_lib.search_no_results_message

--- a/test_sidebar_links.py
+++ b/test_sidebar_links.py
@@ -1,9 +1,10 @@
 from BaseTest import BaseTest
 import WPPost
+from selenium.webdriver.common.by import By
 
 # TestSidebarLinks
 # Written by Angela Korra'ti
-# Last updated 7/5/2023
+# Last updated 7/7/2023
 #
 # This class conducts tests against the sidebar of my test WordPress site.
 
@@ -35,7 +36,12 @@ class TestSidebarLinks(BaseTest):
         """
         self.ac.move_to_element(self.wp_sidebar.recent_posts_list_elements[4]).perform()
         self.wp_sidebar.recent_comments_list_elements[0].click()
-        assert self.driver.current_url == self.wp_lib.wp_base_uri + self.wp_lib.recent_comments_uri
+
+        # 7/7/2023 Looking for MOST of the URI here because the actual comment number changes
+        # depending on when I last set up the test Wordpress database, or if I had to import
+        # multiple times
+        most_of_uri = self.wp_lib.wp_base_uri + self.wp_lib.recent_comments_uri
+        assert self.driver.current_url.startswith(most_of_uri)
         wp_post = WPPost.WPPost(self.driver, self.wp_lib)
         assert wp_post.post_title_element is not None
         assert wp_post.post_title_element.is_displayed()
@@ -48,7 +54,7 @@ class TestSidebarLinks(BaseTest):
         self.ac.move_to_element(self.wp_sidebar.archives_element).perform()
         self.wp_sidebar.archives_list_elements[0].click()
         assert self.driver.current_url == self.wp_lib.wp_base_uri + self.wp_lib.archives_uri
-        page_title = self.driver.find_element_by_class_name(self.wp_lib.page_title_class)
+        page_title = self.driver.find_element(By.CLASS_NAME, self.wp_lib.page_title_class)
         assert page_title is not None
         assert page_title.is_displayed()
         assert page_title.text == self.wp_lib.archives_string + self.wp_lib.archives_title
@@ -60,7 +66,7 @@ class TestSidebarLinks(BaseTest):
         self.ac.move_to_element(self.wp_sidebar.categories_element).perform()
         self.wp_sidebar.categories_list_elements[0].click()
         assert self.driver.current_url == self.wp_lib.wp_base_uri + self.wp_lib.categories_uri
-        page_title = self.driver.find_element_by_class_name(self.wp_lib.page_title_class)
+        page_title = self.driver.find_element(By.CLASS_NAME, self.wp_lib.page_title_class)
         assert page_title is not None
         assert page_title.is_displayed()
         assert page_title.text == self.wp_lib.categories_string + self.wp_lib.categories_title


### PR DESCRIPTION
Selenium 4.3 and later had a bunch of syntax changes I needed to account for in this suite. So this PR contains the following major changes:

1. Changing BaseTest's syntax for declaring the driver and its options
2. Changing every single occurrence of an element find to use the new By syntax

Also, bonus side fix:

3. The comments URI test fails if I do multiple test imports into a clean test copy of the Wordpress database. So I've done an initial fix to try to address this and not worry about whatever comment number is on the end of the URI. I should check in a better fix for this later.